### PR TITLE
Added difficulty options

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -1,6 +1,8 @@
 extends Node
 
 signal game_is_over(final_score: int)
+signal can_pause_changed(can_pause: bool)
+signal can_change_difficulty(can_change_difficulty: bool)
 
 @export var mob_scene: PackedScene
 @onready var start_timer: Timer = $StartTimer
@@ -13,10 +15,16 @@ signal game_is_over(final_score: int)
 @onready var death_sound = $DeathSound
 var score
 
-signal can_pause_changed(can_pause: bool)
+func _ready():
+	Settings.difficulty_changed.connect(on_difficulty_changed)
+	can_change_difficulty.connect($HUD/OptionsMenu.on_can_change_difficulty_changed)
+
+func on_difficulty_changed(new_difficulty):
+	mob_timer.wait_time = Settings.settings.difficulty.enemy_spawn_time
 
 func game_over():
 	can_pause_changed.emit(false)
+	can_change_difficulty.emit(true)
 	score_timer.stop()
 	mob_timer.stop()
 	game_is_over.emit(score)
@@ -24,6 +32,7 @@ func game_over():
 	death_sound.play()
 
 func new_game():
+	can_change_difficulty.emit(false)
 	can_pause_changed.emit(true)
 	score_timer.stop()
 	mob_timer.stop()

--- a/UI/hud.gd
+++ b/UI/hud.gd
@@ -81,3 +81,6 @@ func _on_leaderboard_closed():
 	leaderboard_ui.hide()
 	buttons.show()
 	game_hud.show()
+
+
+

--- a/UI/leaderboard.gd
+++ b/UI/leaderboard.gd
@@ -30,10 +30,13 @@ func remove_invalid_score(score) -> bool:
 	if typeof(score) != TYPE_DICTIONARY:
 		return false
 	var score_dict: Dictionary = score
-	return _valid_username(score_dict) && _valid_score(score_dict)
+	return _valid_username(score_dict) && _valid_score(score_dict) && _valid_difficulty(score_dict)
 
 func _valid_username(score_dict: Dictionary) -> bool:
 	return score_dict.has("username") && typeof(score_dict["username"]) == TYPE_STRING
 
 func _valid_score(score_dict: Dictionary) -> bool:
 	return score_dict.has("score") && (typeof(score_dict["score"]) == TYPE_INT || typeof(score_dict["score"]) == TYPE_FLOAT) && score_dict["score"] > 0
+
+func _valid_difficulty(score_dict: Dictionary) -> bool:
+	return score_dict.has("difficulty") && typeof(score_dict["difficulty"]) == TYPE_DICTIONARY && Settings.available_difficulties.has(score_dict["difficulty"])

--- a/UI/leaderboard_ui.gd
+++ b/UI/leaderboard_ui.gd
@@ -17,11 +17,24 @@ func _ready():
 	_load_scores()
 
 func _load_scores():
+	scores.sort_custom(_sort_by_score_and_difficulty)
 	for score in scores:
 		var username_label: Label = _username_label(score.username)
 		var user_score: Label = _user_score(score.score)
+		var user_difficulty: Label = _user_difficulty(score.difficulty)
 		score_grid_container.add_child(username_label)
 		score_grid_container.add_child(user_score)
+		score_grid_container.add_child(user_difficulty)
+
+func _sort_by_score_and_difficulty(a, b) -> bool:
+	# If the difficulty is higher in the first item
+	if(a.difficulty.enemy_spawn_time < b.difficulty.enemy_spawn_time):
+		return true
+	# If the difficulty is the same for both items but the score in the first
+	# item is higher
+	if(a.difficulty.enemy_spawn_time == b.difficulty.enemy_spawn_time) && (a.score > b.score):
+		return true
+	return false
 
 func _reload_scores():
 	for n in score_grid_container.get_children():
@@ -34,7 +47,7 @@ func _grid_label(text: String) -> Label:
 	var label: Label = Label.new()
 	label.text = text
 	label.theme = SubtitleTheme
-	label.custom_minimum_size = Vector2(230, 0)
+	label.custom_minimum_size = Vector2(160, 0)
 	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	return label
 
@@ -43,6 +56,9 @@ func _username_label(username: String) -> Label:
 
 func _user_score(user_score: int) -> Label:
 	return _grid_label(str(user_score))
+
+func _user_difficulty(user_difficulty) -> Label:
+	return _grid_label(user_difficulty.name)
 
 func _on_go_back_button_pressed():
 	leaderboard_closed.emit()

--- a/UI/leaderboard_ui.tscn
+++ b/UI/leaderboard_ui.tscn
@@ -34,7 +34,7 @@ grow_horizontal = 2
 metadata/_edit_group_ = true
 
 [node name="NameLabel" type="Label" parent="TitleContainer"]
-custom_minimum_size = Vector2(230, 0)
+custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 theme = ExtResource("2_n2nu4")
 text = "Name
@@ -42,12 +42,17 @@ text = "Name
 horizontal_alignment = 1
 
 [node name="ScoreLabel" type="Label" parent="TitleContainer"]
-custom_minimum_size = Vector2(230, 0)
+custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 theme = ExtResource("2_n2nu4")
 text = "Score
 "
 horizontal_alignment = 1
+
+[node name="Label" type="Label" parent="TitleContainer"]
+layout_mode = 2
+theme = ExtResource("2_n2nu4")
+text = "Difficulty"
 
 [node name="ScoreContainer" type="ScrollContainer" parent="."]
 offset_left = 10.0
@@ -61,10 +66,11 @@ scroll_vertical_custom_step = 40.0
 horizontal_scroll_mode = 0
 
 [node name="ScoreGridContainer" type="GridContainer" parent="ScoreContainer"]
+clip_contents = true
 custom_minimum_size = Vector2(460, 450)
 layout_mode = 2
 theme = ExtResource("4_xv1as")
-columns = 2
+columns = 3
 
 [node name="NoScoreContainer" type="CenterContainer" parent="."]
 visible = false

--- a/UI/options_menu.gd
+++ b/UI/options_menu.gd
@@ -5,7 +5,13 @@ signal options_closed
 @onready var volume_slider: HSlider = $VolumeSlider
 @onready var fullscreen_toggle: CheckBox = $FullscreenToggle
 @onready var resolution_options: OptionButton = $ResolutionsList
+@onready var difficulty_options: OptionButton = $DifficultyList
 var main_audio_bus_idx = AudioServer.get_bus_index("Master")
+var can_change_difficulty: bool = true
+
+func on_can_change_difficulty_changed(can_change_difficulty_value):
+	can_change_difficulty = can_change_difficulty_value
+	difficulty_options.disabled = !can_change_difficulty
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -16,8 +22,18 @@ func _ready():
 	volume_slider.value = volume
 	fullscreen_toggle.button_pressed = fullscreen
 	load_resolutions()
+	load_difficulties()
 	set_volume(volume)
 	toggle_fullscreen(fullscreen)
+
+func load_difficulties():
+	var idx: int = 0
+	for diff in Settings.available_difficulties:
+		difficulty_options.add_item(diff.name, idx)
+		if(diff.name == Settings.settings.difficulty.name):
+			difficulty_options.select(idx)
+		idx += 1
+	pass
 
 func load_resolutions():
 	# Loop through the available resolutions array, parse the resolutions, 
@@ -73,5 +89,6 @@ func _on_accept_button_pressed():
 	if(res_vector != Vector2i.ZERO):
 		Settings.settings.resolution_x = res_vector.x
 		Settings.settings.resolution_y = res_vector.y
+	Settings.settings["difficulty"] = Settings.available_difficulties[difficulty_options.selected]
 	Settings.save_settings()
 	options_closed.emit()

--- a/UI/options_menu.tscn
+++ b/UI/options_menu.tscn
@@ -27,6 +27,16 @@ text = "Options"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="DifficultyLabel" type="Label" parent="."]
+layout_mode = 2
+theme = ExtResource("3_s6jy7")
+text = "Difficulty
+"
+
+[node name="DifficultyList" type="OptionButton" parent="."]
+layout_mode = 2
+theme = ExtResource("3_s6jy7")
+
 [node name="VolumeLabel" type="Label" parent="."]
 layout_mode = 2
 theme = ExtResource("3_s6jy7")

--- a/UI/score_confirmation.gd
+++ b/UI/score_confirmation.gd
@@ -25,7 +25,7 @@ func _on_text_edit_text_changed():
 	cursor_column = text_edit.get_caret_column()
 
 func _on_button_pressed():
-	var user_score: Dictionary = { "username": current_text, "score": score }
+	var user_score: Dictionary = { "username": current_text, "score": score, "difficulty": Settings.settings.difficulty}
 	Leaderboard.add_score(user_score, true)
 	score_confirmed.emit()
 	score = 0

--- a/settings.gd
+++ b/settings.gd
@@ -1,15 +1,32 @@
 extends Node
 
+signal difficulty_changed(difficulty)
+
 const JSONFileParser = preload("res://Objects/json_file_parser.gd")
 @onready var json_file_parser: JSONFileParser = JSONFileParser.new()
 var master_audio_bus_idx = AudioServer.get_bus_index("Master")
+var available_difficulties = [
+	{
+		"name": "Easy",
+		"enemy_spawn_time": 2.0
+	}, 
+	{
+		"name":"Medium",
+		"enemy_spawn_time": 1.0
+	}, 
+	{
+		"name": "Hard",
+		"enemy_spawn_time": 0.5
+	}]
+var available_resolutions = ["1920x1080", "1366x768", "1280x720", "1024x768", "800x600", "640x480"]
+# Default Settings
 var settings: Dictionary = {
 	"master_volume": AudioServer.get_bus_volume_db(master_audio_bus_idx),
 	"fullscreen": false,
 	"resolution_x": 1920,
-	"resolution_y": 1080
+	"resolution_y": 1080,
+	"difficulty": available_difficulties[1]
 }
-var available_resolutions = ["1920x1080", "1366x768", "1280x720", "1024x768", "800x600", "640x480"]
 var file_path = "user://settings.json"
 
 func _ready():
@@ -24,16 +41,18 @@ func _ready():
 	settings = data
 
 func save_settings():
+	difficulty_changed.emit(settings.difficulty)
 	json_file_parser.json_to_file(file_path, settings)
 
 func validate_settings(settings_dict: Dictionary) -> bool:
 	if (!settings_dict.has("master_volume") || !settings_dict.has("fullscreen") || !settings_dict.has("resolution_x") || 
-	!settings_dict.has("resolution_y")):
+	!settings_dict.has("resolution_y") || !settings_dict.has("difficulty")):
 		return false
-	var master_volume = settings["master_volume"]
-	var fullscreen = settings["fullscreen"]
-	var resolution_x = int(settings["resolution_x"])
-	var resolution_y = int(settings["resolution_y"])
+	var master_volume = settings_dict["master_volume"]
+	var fullscreen = settings_dict["fullscreen"]
+	var resolution_x = int(settings_dict["resolution_x"])
+	var resolution_y = int(settings_dict["resolution_y"])
+	var difficulty = settings_dict["difficulty"]
 	if(master_volume == null || typeof(master_volume) != TYPE_FLOAT || master_volume < -80.0 || master_volume > 0):
 		return false
 	if(fullscreen == null || typeof(fullscreen) != TYPE_BOOL):
@@ -41,5 +60,11 @@ func validate_settings(settings_dict: Dictionary) -> bool:
 	if(resolution_x == null || typeof(resolution_x) != TYPE_INT):
 		return false
 	if(resolution_y == null || typeof(resolution_y) != TYPE_INT):
+		return false
+	var res_arr: PackedStringArray = [resolution_x, resolution_y]
+	if(!available_resolutions.has("x".join(res_arr))):
+		return false
+	if(difficulty == null || typeof(difficulty) != TYPE_DICTIONARY || !available_difficulties.has(difficulty) ||
+	!difficulty.has("name") || !difficulty.has("enemy_spawn_time")):
 		return false
 	return true


### PR DESCRIPTION
Expanded Settings Dictionary to include difficulty option selected. Added difficulty dropdown in the Options Menu (it can only change if the game hasn't started yet).
Added necessary login to include the difficulty option when the game is over.
Added logic to display and save difficulty in the Leaderboard Screen.
Updated logic on Main.gd to spawn enemies in the time set by the selected difficulty.

Closes #6 